### PR TITLE
Customer List visible

### DIFF
--- a/src/pages/NewProduct/index.tsx
+++ b/src/pages/NewProduct/index.tsx
@@ -73,10 +73,10 @@ export default function NewProduct() {
       setLoading(true);
       const { data, error } = await supabase
         .from('customers')
-        .select('id, name, phone, location')
-        .eq('added_by', currentInternObj?.id);
+        .select('id, name, phone, location');
 
       if (error) {
+        console.error("Error fetching customers:", error);
         setLoading(false);
         return;
       }


### PR DESCRIPTION
The key change is removing the .eq('added_by', currentInternObj?.id) filter from the query, which was restricting the results to only show customers added by the current intern. Now it will fetch all customers from your Supabase database.

This should populate your dropdown with all customers that have been added to your database, regardless of which intern added them.
